### PR TITLE
fix to can import assert_html from with_asserts.context_manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,9 @@ Into this::
     with self.assertHTML(resp, 'input[name="email"]') as (elem,):
         self.assertEqual(elem.value, 'bob@example.com')
 
+Or this (useful outside of TestCase subclasses, e.g. py.test):
+    with assert_html(resp, 'input[name="email"]') as (elem,):
+        self.assertEqual(elem.value, 'bob@example.com')  
 
 Links
 ------

--- a/tests/simple/tests/test_html.py
+++ b/tests/simple/tests/test_html.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from with_asserts.case import TestCase as HTMLTestCase
 from with_asserts.mixin import AssertHTMLMixin
+from with_asserts.context_manager import assert_html
 
 import lxml.html
 
@@ -142,6 +143,13 @@ class HTMLTestCaseTest(HTMLTestCase):
             self.assertIsInstance(html, lxml.html.HtmlElement)
             self.assertEqual('Selector Test', html.find('head/title').text)
 
+class BareContextManagerTest(TestCase):
+    def test_document(self):
+        resp = self.client.get('/template/selectors/')
+
+        with assert_html(resp) as html:
+            self.assertIsInstance(html, lxml.html.HtmlElement)
+            self.assertEqual('Selector Test', html.find('head/title').text)
 # TODO:
 # expected_tag
 # expected_attrs

--- a/with_asserts/context_manager.py
+++ b/with_asserts/context_manager.py
@@ -18,8 +18,13 @@ class ElementIDNotFound(HTMLNotPresent):
 class AssertHTMLContext(object):
     """Context manager for AssertHTMLMixin.assertHTML"""
 
-    def __init__(self, response, test_case, selector, element_id,
-                 status_code, msg):
+    def __init__(self, response,
+                 selector=None, 
+                 element_id=None,
+                 expected=None,
+                 status_code=200,
+                 msg=None,
+                 test_case=None):
         self.response = response
         self.test_case = test_case
         self.status_code = status_code
@@ -31,7 +36,10 @@ class AssertHTMLContext(object):
 
     def __enter__(self):
         # Similar to assertContains(), we verify the status code
-        self.test_case.assertEqual(self.response.status_code, self.status_code)
+        if self.test_case is not None:
+            self.test_case.assertEqual(self.response.status_code, self.status_code)
+        else:
+            assert self.response.status_code == self.status_code
 
         # TODO consider validating self.response['Content-Type']
 
@@ -61,3 +69,6 @@ class AssertHTMLContext(object):
 
     def __exit__(self, exc_type, exc_value, tb):
         pass
+
+def assert_html(*args, **kwargs):
+    return AssertHTMLContext(*args, **kwargs)

--- a/with_asserts/mixin.py
+++ b/with_asserts/mixin.py
@@ -5,22 +5,9 @@ __all__ = ['AssertHTMLMixin']
 
 
 class AssertHTMLMixin(object):
-    def assertHTML(self, response,
-                   selector=None, element_id=None,
-                   expected=None,
-                   status_code=200,
-                   msg=None):
-
-        context = AssertHTMLContext(
-            response,
-            test_case=self,
-            selector=selector,
-            element_id=element_id,
-            status_code=status_code,
-            msg=msg
-        )
-
-        return context
+    def assertHTML(self, *args, **kwargs):
+        kwargs['test_case'] = self
+        return AssertHTMLContext(*args, **kwargs)
 
     def assertNotHTML(self, *args, **kwargs):
         try:


### PR DESCRIPTION
Small fixes in edge cases and now you can use `assert_html` outside of `TestCase` subclasses, e.g. `py.test`
